### PR TITLE
fixed bug in the `list_files` function

### DIFF
--- a/annotated_images/split.py
+++ b/annotated_images/split.py
@@ -18,13 +18,11 @@ def list_files(directory):
     """Returns files in a given directory
     Default only splits annotated images, if no annotations are found then all images are split.
     """
-    files = glob.glob(directory + '*.json')
+    files = glob.glob(os.path.join(directory, '*.json'))
     if len(files) == 0:
-        files = glob.glob(directory + '*.xml')
+        files = glob.glob(os.path.join(directory, '*.xml'))
     if len(files) == 0:
-        files = glob.glob
-    if len(files) == 0:
-        files = glob.glob(directory + '*.*')
+        files = glob.glob(os.path.join(directory, '*.*'))
     return files
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ classifiers = [
     'Topic :: Utilities']
 
 setup(name='annotated_images',
-      version='0.1.4',
+      version='0.1.5',
       description='Split training data images into training, validation and test (dataset) folders.',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
Apparently, the package wouldn't work at all. 

- First, `files = glob.glob` would raise an error every time I ran the package because the variable `file` will always be a function.

- Second, `directory + '*.json'` would not work because there is a missing slash ('/' for Linux based systems, for instance). Using `os.path.join`, the correct slash will be added.

By the way, I was thinking that you forgot to add a file format on the `files = glob.glob` line, so feel free to add back the two lines I removed (along with the file format) :)